### PR TITLE
Rename SS to CS

### DIFF
--- a/examples/imuSPI.py
+++ b/examples/imuSPI.py
@@ -4,18 +4,18 @@ import time
 cycle_time = 0.001
 def main():
     with (SmartWave().connect() as sw):
-        sw.createSPIConfig(miso_pin_name="B1", mosi_pin_name="B2", ss_pin_name="B3", sclk_pin_name="B4")
+        sw.createSPIConfig(miso_pin_name="B1", mosi_pin_name="B2", cs_pin_name="B3", sclk_pin_name="B4")
         with sw.createSPIConfig(
                 bit_width=16,
                 miso_pin_name="A1",
                 mosi_pin_name="A2",
                 sclk_pin_name="A3",
-                ss_pin_name="A4",
-                clock_speed=2e6,
+                cs_pin_name="A4",
+                clock_speed=int(2e6),
                 bit_numbering="MSB") as spi:
             whoami = spi.write([0x8f00])[0]
             print(whoami)
-
+            input()
             spi.write([0x1010])
 
             start = time.time()
@@ -27,6 +27,7 @@ def main():
                 val = val if val < 0x8000 else val - 0x10000
                 print(val)
                 next_time += cycle_time
+                input()
 
             print(time.time() - start)
 

--- a/src/SmartWaveAPI/configitems/spiconfig.py
+++ b/src/SmartWaveAPI/configitems/spiconfig.py
@@ -10,7 +10,7 @@ class SPIConfig(Config):
                  sclk_pin: Union[Pin, None] = None,
                  mosi_pin: Union[Pin, None] = None,
                  miso_pin: Union[Pin, None] = None,
-                 ss_pin: Union[Pin, None] = None,
+                 cs_pin: Union[Pin, None] = None,
                  clockspeed: Union[int, None] = None,
                  bit_width:  Union[int, None] = None,
                  bit_numbering: Union[Literal["MSB", "LSB"], None] = None,
@@ -23,7 +23,7 @@ class SPIConfig(Config):
         :param Union[Pin, None] sclk_pin: The pin to use for SCLK
         :param Union[Pin, None] mosi_pin: The pin to use for MOSI
         :param Union[Pin, None] miso_pin: The pin to use for MISO
-        :param Union[Pin, None] ss_pin: The pin to use for SS
+        :param Union[Pin, None] cs_pin: The pin to use for CS
         :param int clockspeed: The transmission clock speed in Hz
         :param int bit_width: The bit width of the SPI transmissions
         :param Literal["MSB", "LSB"] bit_numbering: Whether to transmit MSB-first or LSB-first
@@ -48,7 +48,7 @@ class SPIConfig(Config):
         self._driver.pins['SCLK'] = sclk_pin if sclk_pin is not None else device.getNextAvailablePin()
         self._driver.pins['MOSI'] = mosi_pin if mosi_pin is not None else device.getNextAvailablePin()
         self._driver.pins['MISO'] = miso_pin if miso_pin is not None else device.getNextAvailablePin()
-        self._driver.pins['SS'] = ss_pin if ss_pin is not None else device.getNextAvailablePin()
+        self._driver.pins['CS'] = cs_pin if cs_pin is not None else device.getNextAvailablePin()
 
         stimulus = device.getNextAvailableStimulus()
         stimulus.sampleBitWidth = 32

--- a/src/SmartWaveAPI/configitems/spidriver.py
+++ b/src/SmartWaveAPI/configitems/spidriver.py
@@ -45,11 +45,11 @@ class SPIDriver(Driver):
             "SCLK": None,
             "MOSI": None,
             "MISO": None,
-            "SS": None,
+            "CS": None,
         }
         self.pinNumbers: Dict[str, int] = {
             "SCLK": 0,
-            "SS": 1,
+            "CS": 1,
             "MOSI": 2,
             "MISO": 3,
         }

--- a/src/SmartWaveAPI/smartwave.py
+++ b/src/SmartWaveAPI/smartwave.py
@@ -583,7 +583,7 @@ class SmartWave(object):
                         sclk_pin_name: Optional[str] = None,
                         mosi_pin_name: Optional[str] = None,
                         miso_pin_name: Optional[str] = None,
-                        ss_pin_name: Optional[str] = None,
+                        cs_pin_name: Optional[str] = None,
                         clock_speed: Optional[int] = None,
                         bit_width: Optional[int] = None,
                         bit_numbering: Optional[Literal["MSB", "LSB"]] = None,
@@ -595,7 +595,7 @@ class SmartWave(object):
         :param str sclk_pin_name: The name of the pin to use for SCLK
         :param str mosi_pin_name: The name of the pin to use for MOSI
         :param str miso_pin_name: The name of the pin to use for MISO
-        :param str ss_pin_name: The name of the pin to use for SS
+        :param str cs_pin_name: The name of the pin to use for CS
         :param int clock_speed: The transmission clock speed in Hz
         :param int bit_width: The bit width of the SPI transmissions
         :param Literal["MSB", "LSB"] bit_numbering: Whether to transmit MSB-first or LSB-first
@@ -608,13 +608,13 @@ class SmartWave(object):
         sclkPin = self.getPin(sclk_pin_name) if sclk_pin_name else None
         misoPin = self.getPin(miso_pin_name) if miso_pin_name else None
         mosiPin = self.getPin(mosi_pin_name) if mosi_pin_name else None
-        ssPin = self.getPin(ss_pin_name) if ss_pin_name else None
+        csPin = self.getPin(cs_pin_name) if cs_pin_name else None
 
         config: SPIConfig = SPIConfig(self,
                                       sclkPin,
                                       mosiPin,
                                       misoPin,
-                                      ssPin,
+                                      csPin,
                                       clock_speed,
                                       bit_width,
                                       bit_numbering,


### PR DESCRIPTION
Reject this if we want to immediately rename MISO and MOSI too, but then we'd have to do that in the WebGUI too for completeness.